### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ app.use('/', router);
 app.listen(5000);
 ```
 
-#Credits#
+# Credits #
 * **[xmlbuilder-js](https://github.com/oozcitak/xmlbuilder-js)** by [oozcitak](https://github.com/oozcitak).
 * **[jade](https://github.com/visionmedia/jade)** by [visionmedia](https://github.com/visionmedia).
 * **[connect](https://github.com/senchalabs/connect)** by [senchalabs](https://github.com/senchalabs).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
